### PR TITLE
Fix exception where property animator is not properly released

### DIFF
--- a/Sources/ToastUI/VisualEffectView.swift
+++ b/Sources/ToastUI/VisualEffectView.swift
@@ -231,5 +231,9 @@ internal extension VisualEffectView.Representable {
       hostingController.view.setNeedsDisplay()
     }
     #endif
+
+    deinit {
+      animator.stopAnimation(true)
+    }
   }
 }


### PR DESCRIPTION
Explicitly set the `UIViewPropertyAnimator` for blur intensity to stopped state when deinitializing`VisualEffectView`, else a `NSInternalInconsistencyException` will be thrown.