### PR TITLE
Release 1.3.0

### DIFF
--- a/.github/workflows/jazzy.yml
+++ b/.github/workflows/jazzy.yml
@@ -4,14 +4,14 @@ on:
   push:
     tags:
       - '*'
+  release:
+    types: [ published ]
 
 jobs:
   jazzy:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Xcode select
-      run: sudo xcode-select -s /Applications/Xcode_12.app
     - name: Get version
       run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\//}
     - name: Install jazzy

--- a/.github/workflows/pods.yml
+++ b/.github/workflows/pods.yml
@@ -1,0 +1,20 @@
+name: CocoaPods
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types: [ published ]
+
+jobs:
+  pod:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint CocoaPods spec
+        run: pod spec lint
+      - name: Publish to CocoaPods trunk
+        run: pod trunk push
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,5 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Xcode select
-      run: sudo xcode-select -s /Applications/Xcode_12.app
     - name: Xcode build
       run: xcodebuild clean build -sdk iphoneos -scheme ToastUI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,35 @@ All notable changes to this project will be documented in this file. `ToastUI` a
 
 #### 1.x Releases
 
+* `1.3.0` Releases - [1.3.0](#130)
 * `1.2.x` Releases - [1.2.0](#120) | [1.2.1](#121)
 * `1.1.x` Releases - [1.1.0](#110) | [1.1.1](#111)
 * `1.0.x` Releases - [1.0.0](#100) | [1.0.1](#101) | [1.0.2](#102)
+
+---
+
+## [1.3.0](https://github.com/quanshousio/ToastUI/releases/tag/1.3.0)
+
+Released on 2020-11-14.
+
+#### Added
+
+* `dismissAfter` handle for `ToastViewItemModifier`.
+  + Added by [Quan Tran](https://github.com/quanshousio) in Pull Request [#13](https://github.com/quanshousio/ToastUI/pull/13).
+
+#### Updated
+
+* New example of `ToastViewStyle` and minor refactoring on `ToastUISample`.
+  + Updated by [Quan Tran](https://github.com/quanshousio) in Pull Request [#13](https://github.com/quanshousio/ToastUI/pull/13).
+* Multi-line text alignment for label of built-in `ToastViewStyle` is center by default.
+  + Updated by [Quan Tran](https://github.com/quanshousio) in Pull Request [#13](https://github.com/quanshousio/ToastUI/pull/13).
+* GitHub actions for pushing to CocoaPods trunk and minor changes to GitHub actions.
+  + Updated by [Quan Tran](https://github.com/quanshousio) in Pull Request [#13](https://github.com/quanshousio/ToastUI/pull/13).
+
+#### Removed
+
+* `ToastView` intializer with `ToastViewStyleConfiguration`.
+  + Removed by [Quan Tran](https://github.com/quanshousio) in Pull Request [#13](https://github.com/quanshousio/ToastUI/pull/13).
 
 ---
 
@@ -15,6 +41,7 @@ All notable changes to this project will be documented in this file. `ToastUI` a
 Released on 2020-10-09.
 
 #### Updated
+
 * Minor changes to GitHub actions.
   + Updated by [Quan Tran](https://github.com/quanshousio) in Pull Request [#12](https://github.com/quanshousio/ToastUI/pull/12).
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ For more detailed documentation, please see **[here](https://quanshousio.github.
 There are two types of `toast()` view modifier. For more usage information, check out the [examples](ToastUISample).
 
 * `toast(isPresented:dismissAfter:onDismiss:content:)` – presents a toast when the given boolean binding is true.
-* `toast(item:onDismiss:content:)` – presents a toast using the given item as a data source for the toast's content.
+* `toast(item:dismissAfter:onDismiss:content:)` – presents a toast using the given item as a data source for the toast's content.
 
 #### ToastView
 
@@ -269,10 +269,11 @@ Quan Tran ([@quanshousio](https://quanshousio.com))
 ## Acknowledgements
 
 * [Fruta](https://developer.apple.com/documentation/app_clips/fruta_building_a_feature-rich_app_with_swiftui) - `UIVisualEffectView` wrapper for SwiftUI written by Apple.
-* [OnChangeOniOS13](https://stackoverflow.com/a/62523475) - `onChange` view modifier for iOS 13.
-* [ScaledMetricOniOS13](https://gist.github.com/apptekstudios/e5f282a67beaa85dc725d1d98ec74191) - `ScaledMetric` property wrapper for iOS 13.
-* [SVProgressHUD](https://github.com/SVProgressHUD/SVProgressHUD) - original design of the circular progress HUD.
-* [SwiftUI Custom Styling](https://swiftui-lab.com/custom-styling) - an informative article about SwiftUI custom styling.
+* [Label](https://fivestars.blog/swiftui/label.html) - an informative article about SwiftUI `Label` and style erasers by Five Stars.
+* [OnChangeOniOS13](https://stackoverflow.com/a/62523475) - `onChange` view modifier for iOS 13 by Damiaan Dufaux.
+* [ScaledMetricOniOS13](https://blog.apptekstudios.com/2020/06/scaledmetric-on-ios-13) - `ScaledMetric` property wrapper for iOS 13 by Apptek Studios.
+* [SVProgressHUD](https://github.com/SVProgressHUD/SVProgressHUD) - original design of the circular progress HUD by Sam Vermette and Tobias Tiemerding.
+* [SwiftUI Custom Styling](https://swiftui-lab.com/custom-styling) - an informative article about SwiftUI custom styling by The SwiftUI Lab.
 
 ## License
 

--- a/Sources/ToastUI/DefaultToastViewStyle.swift
+++ b/Sources/ToastUI/DefaultToastViewStyle.swift
@@ -106,6 +106,7 @@ public struct IndefiniteProgressToastViewStyle: ToastViewStyle {
         label
           .font(.headline)
           .foregroundColor(.secondary)
+          .multilineTextAlignment(.center)
       }
       .padding(paddingSize)
       .background(backgroundColor)
@@ -182,6 +183,7 @@ where Value: BinaryFloatingPoint
         label
           .font(.headline)
           .foregroundColor(.secondary)
+          .multilineTextAlignment(.center)
       }
       .padding(paddingSize)
       .background(backgroundColor)
@@ -222,6 +224,7 @@ public struct SuccessToastViewStyle: ToastViewStyle {
         label
           .font(.headline)
           .foregroundColor(.secondary)
+          .multilineTextAlignment(.center)
       }
       .padding(paddingSize)
       .background(backgroundColor)
@@ -262,6 +265,7 @@ public struct ErrorToastViewStyle: ToastViewStyle {
         label
           .font(.headline)
           .foregroundColor(.secondary)
+          .multilineTextAlignment(.center)
       }
       .padding(paddingSize)
       .background(backgroundColor)
@@ -302,6 +306,7 @@ public struct WarningToastViewStyle: ToastViewStyle {
         label
           .font(.headline)
           .foregroundColor(.secondary)
+          .multilineTextAlignment(.center)
       }
       .padding(paddingSize)
       .background(backgroundColor)
@@ -342,6 +347,7 @@ public struct InfoToastViewStyle: ToastViewStyle {
         label
           .font(.headline)
           .foregroundColor(.secondary)
+          .multilineTextAlignment(.center)
       }
       .padding(paddingSize)
       .background(backgroundColor)

--- a/Sources/ToastUI/ToastUI.swift
+++ b/Sources/ToastUI/ToastUI.swift
@@ -44,18 +44,21 @@ extension View {
   ///     create a toast representation of the item.
   ///     If the identity changes, the function ignores the new item unless the
   ///     old item is dismissed. This behavior might changes in the future.
+  ///   - dismissAfter: An amount of time (in seconds) to dismiss the toast.
   ///   - onDismiss: A closure executed when the toast is dismissed.
   ///   - content: A closure returning the content of the toast.
   ///
   /// - Returns: A modified representation of this view.
   public func toast<Item, Content>(
     item: Binding<Item?>,
+    dismissAfter: Double? = nil,
     onDismiss: (() -> Void)? = nil,
     @ViewBuilder content: @escaping (Item) -> Content
-  ) -> some View where Item: Identifiable, Content: View {
+  ) -> some View where Item: Identifiable & Equatable, Content: View {
     modifier(
       ToastViewItemModifier<Item, Content>(
         item: item,
+        dismissAfter: dismissAfter,
         onDismiss: onDismiss,
         content: content
       )

--- a/Sources/ToastUI/ToastView.swift
+++ b/Sources/ToastUI/ToastView.swift
@@ -60,14 +60,6 @@ extension ToastView {
     )
   }
 
-  /// Creates a `ToastView` based on a style configuration.
-  ///
-  /// - Parameter configuration: A `ToastView` style configuration.
-  public init(_ configuration: ToastViewStyleConfiguration)
-  where Background == EmptyView, Label == EmptyView, Content == EmptyView {
-    self.configuration = configuration
-  }
-
   /// Creates an empty `ToastView` with text label from a localized string.
   ///
   /// - Parameter titleKey: The key for the `ToastView`'s localized title.

--- a/ToastUI.podspec
+++ b/ToastUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = 'ToastUI'
-  s.version     = '1.2.1'
+  s.version     = '1.3.0'
   s.summary     = 'A simple way to show toast in SwiftUI.'
   s.description = 'ToastUI provides you a simple way to show toast, heads-up display (HUD), custom alert or any SwiftUI views on top of everything in SwiftUI.'
 

--- a/ToastUISample/Shared/AdvancedExamples.swift
+++ b/ToastUISample/Shared/AdvancedExamples.swift
@@ -8,16 +8,6 @@
 import SwiftUI
 import ToastUI
 
-// swiftlint:disable identifier_name
-struct ToastItem: Identifiable, Equatable {
-  let id = UUID()
-  var content: AnyView
-
-  static func == (lhs: ToastItem, rhs: ToastItem) -> Bool {
-    lhs.id == rhs.id
-  }
-}
-
 struct CustomizedToastWithoutToastViewExample: View {
   @State private var presentingToast: Bool = false
   @State private var blurBackground: Bool = true
@@ -70,8 +60,8 @@ struct CustomizedToastWithoutToastViewExample: View {
 
 struct CustomizedToastUsingItemExample: View {
   private var toastItems = ["First Toast Item", "Second Toast Item"]
-  @State private var selectedToast = 0
 
+  @State private var selectedToast = 0
   @State private var toastItem: ToastItem?
   @State private var username: String = ""
   @State private var email: String = ""

--- a/ToastUISample/Shared/AdvancedExamples.swift
+++ b/ToastUISample/Shared/AdvancedExamples.swift
@@ -200,3 +200,58 @@ struct ShowSuccessToastAfterCompletedExample: View {
     }
   }
 }
+
+struct CustomToastViewStyle: ToastViewStyle {
+  var color: UIColor
+
+  func makeBody(configuration: Configuration) -> some View {
+    CustomToastView(configuration: configuration, color: color)
+  }
+
+  struct CustomToastView: View {
+    let configuration: Configuration
+    let color: UIColor
+
+    var body: some View {
+      VStack {
+        // we skipped the background view of the ToastView
+        // configuration.background
+        configuration.content
+        configuration.label
+      }
+      .padding()
+      .background(
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.init(color))
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      )
+    }
+  }
+}
+
+// swiftlint:disable:next type_name
+struct CustomizedToastUsingToastViewStyleExample: View {
+  @State private var presentingToast: Bool = false
+  @State private var brightness: CGFloat = 0.5
+
+  var body: some View {
+    VStack {
+      HStack {
+        Text("Brightness")
+        Slider(value: $brightness, in: 0 ... 1)
+      }
+      CustomButton("Tap me") {
+        presentingToast = true
+      }
+    }
+    .padding()
+    .toast(isPresented: $presentingToast, dismissAfter: 2.0) {
+      ToastView("This is the logo of ToastUI") { // label
+        ToastUIImage(width: 67.43) // content
+      } background: {
+        // background view will be ignored by CustomToastViewStyle
+      }
+      .toastViewStyle(CustomToastViewStyle(color: .init(white: brightness, alpha: 1)))
+    }
+  }
+}

--- a/ToastUISample/Shared/Auxiliaries.swift
+++ b/ToastUISample/Shared/Auxiliaries.swift
@@ -1,0 +1,82 @@
+//
+//  Auxiliaries.swift
+//  ToastUISample
+//
+//  Created by Quan Tran on 11/14/20.
+//
+
+import SwiftUI
+
+// swiftlint:disable identifier_name
+struct ToastItem: Identifiable, Equatable {
+  let id = UUID()
+  var content: AnyView
+
+  static func == (lhs: ToastItem, rhs: ToastItem) -> Bool {
+    lhs.id == rhs.id
+  }
+}
+
+struct ExampleItem<Destination>: View where Destination: View {
+  var destination: Destination
+  var description: String
+
+  var body: some View {
+    NavigationLink(destination: destination) {
+      VStack(alignment: .leading) {
+        Text(description).lineLimit(20)
+      }
+    }
+  }
+}
+
+struct CustomButton: View {
+  var label: String
+  var width: CGFloat
+  var height: CGFloat
+  var action: () -> Void
+
+  init(
+    _ label: String,
+    width: CGFloat = 100,
+    height: CGFloat = 12,
+    _ action: @escaping () -> Void
+  ) {
+    self.label = label
+    self.width = width
+    self.height = height
+    self.action = action
+  }
+
+  @ViewBuilder var body: some View {
+    #if os(iOS)
+    Button(action: action) {
+      Text(label)
+        .bold()
+        .foregroundColor(.white)
+        .frame(maxWidth: width, maxHeight: height)
+        .padding()
+        .background(Color.accentColor)
+        .cornerRadius(8.0)
+    }
+    #endif
+
+    #if os(tvOS)
+    Button(action: action) {
+      Text(label)
+        .bold()
+        .foregroundColor(.white)
+    }
+    #endif
+  }
+}
+
+struct ToastUIImage: View {
+  var width: CGFloat
+
+  var body: some View {
+    Image("ToastUI")
+      .resizable()
+      .frame(width: width, height: width / 1.873)
+  }
+}

--- a/ToastUISample/Shared/BasicExamples.swift
+++ b/ToastUISample/Shared/BasicExamples.swift
@@ -127,10 +127,7 @@ struct ToastViewWithCustomBackgroundExample: View {
       }
       .toast(isPresented: $presentingToast, dismissAfter: 2.0) {
         ToastView {
-          Image(systemName: "timelapse")
-            .resizable()
-            .frame(width: 36, height: 36)
-            .foregroundColor(.accentColor)
+          ToastUIImage(width: 67.43)
         } label: {
           Text("Hello from ToastUI")
         } background: {
@@ -158,7 +155,7 @@ struct CustomizedAlertExample: View {
     .toast(isPresented: $presentingToast) {
       ToastView {
         VStack {
-          Text("You can create custom alert with ToastView")
+          Text("You can create a customized alert with ToastView")
             .padding(.bottom)
             .multilineTextAlignment(.center)
 

--- a/ToastUISample/Shared/ContentView.swift
+++ b/ToastUISample/Shared/ContentView.swift
@@ -8,60 +8,6 @@
 import SwiftUI
 import ToastUI
 
-struct ExampleItem<Destination>: View where Destination: View {
-  var destination: Destination
-  var description: String
-
-  var body: some View {
-    NavigationLink(destination: destination) {
-      VStack(alignment: .leading) {
-        Text(description).lineLimit(20)
-      }
-    }
-  }
-}
-
-struct CustomButton: View {
-  var label: String
-  var width: CGFloat
-  var height: CGFloat
-  var action: () -> Void
-
-  init(
-    _ label: String,
-    width: CGFloat = 100,
-    height: CGFloat = 12,
-    _ action: @escaping () -> Void
-  ) {
-    self.label = label
-    self.width = width
-    self.height = height
-    self.action = action
-  }
-
-  @ViewBuilder var body: some View {
-    #if os(iOS)
-    Button(action: action) {
-      Text(label)
-        .bold()
-        .foregroundColor(.white)
-        .frame(maxWidth: width, maxHeight: height)
-        .padding()
-        .background(Color.accentColor)
-        .cornerRadius(8.0)
-    }
-    #endif
-
-    #if os(tvOS)
-    Button(action: action) {
-      Text(label)
-        .bold()
-        .foregroundColor(.white)
-    }
-    #endif
-  }
-}
-
 struct ContentView: View {
   var body: some View {
     NavigationView {
@@ -101,7 +47,7 @@ struct ContentView: View {
           )
           ExampleItem(
             destination: CocoaBlurModifierExample(),
-            description: "cocoaBlur() view modifier"
+            description: "cocoaBlur view modifier"
           )
         }
 
@@ -125,7 +71,7 @@ struct ContentView: View {
         }
       }
       .navigationBarTitle("ToastUI")
-      .navigationBarItems(trailing: Image("ToastUI").resizable().frame(width: 52.45, height: 28))
+      .navigationBarItems(trailing: ToastUIImage(width: 52.45))
     }
   }
 }

--- a/ToastUISample/Shared/ContentView.swift
+++ b/ToastUISample/Shared/ContentView.swift
@@ -107,6 +107,10 @@ struct ContentView: View {
 
         Section(header: Text("Advanced examples")) {
           ExampleItem(
+            destination: CustomizedToastUsingToastViewStyleExample(),
+            description: "Customized toast using custom ToastViewStyle"
+          )
+          ExampleItem(
             destination: CustomizedToastWithoutToastViewExample(),
             description: "Customized toast without using ToastView"
           )

--- a/ToastUISample/ToastUISample.xcodeproj/project.pbxproj
+++ b/ToastUISample/ToastUISample.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3348BB39256076B30084DBEB /* Auxiliaries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3348BB38256076B30084DBEB /* Auxiliaries.swift */; };
+		3348BB3A256076B30084DBEB /* Auxiliaries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3348BB38256076B30084DBEB /* Auxiliaries.swift */; };
 		337A107A24CAC97900362CBE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 337A107924CAC97900362CBE /* AppDelegate.swift */; };
 		337A107E24CAC97A00362CBE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 337A107D24CAC97A00362CBE /* Assets.xcassets */; };
 		337A108124CAC97A00362CBE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 337A108024CAC97A00362CBE /* Preview Assets.xcassets */; };
@@ -27,6 +29,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3348BB38256076B30084DBEB /* Auxiliaries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Auxiliaries.swift; sourceTree = "<group>"; };
 		337A103A24CAC3D200362CBE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		337A104D24CAC41900362CBE /* AdvancedExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdvancedExamples.swift; sourceTree = "<group>"; };
 		337A104E24CAC41A00362CBE /* BasicExamples.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicExamples.swift; sourceTree = "<group>"; };
@@ -140,6 +143,7 @@
 		337A10A124CAC9BA00362CBE /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				3348BB38256076B30084DBEB /* Auxiliaries.swift */,
 				337A103A24CAC3D200362CBE /* ContentView.swift */,
 				337A104E24CAC41A00362CBE /* BasicExamples.swift */,
 				337A104D24CAC41900362CBE /* AdvancedExamples.swift */,
@@ -299,6 +303,7 @@
 				337A10A724CACABB00362CBE /* AdvancedExamples.swift in Sources */,
 				337A10A824CACABB00362CBE /* ContentView.swift in Sources */,
 				337A10A624CACABB00362CBE /* BasicExamples.swift in Sources */,
+				3348BB3A256076B30084DBEB /* Auxiliaries.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -310,6 +315,7 @@
 				337A10A524CACABA00362CBE /* ContentView.swift in Sources */,
 				337A109224CAC99E00362CBE /* SceneDelegate.swift in Sources */,
 				337A10A424CACABA00362CBE /* AdvancedExamples.swift in Sources */,
+				3348BB39256076B30084DBEB /* Auxiliaries.swift in Sources */,
 				337A10A324CACABA00362CBE /* BasicExamples.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
#### Added
* `dismissAfter` handle for `ToastViewItemModifier`.

#### Updated
* New example of `ToastViewStyle` and minor refactoring on `ToastUISample`.
* Multi-line text alignment for label of built-in `ToastViewStyle` is center by default.
* GitHub actions for pushing to CocoaPods trunk and minor changes to GitHub actions.

#### Removed
* `ToastView` initializer with `ToastViewStyleConfiguration`.