### PR TITLE
Fix the "'shared' is unavailable in application extensions" error for Xcode 13

### DIFF
--- a/Sources/ToastUI/ToastUI.swift
+++ b/Sources/ToastUI/ToastUI.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOSApplicationExtension, unavailable)
 public extension View {
   // MARK: Presenting Toast
 

--- a/Sources/ToastUI/ToastViewModifier.swift
+++ b/Sources/ToastUI/ToastViewModifier.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 #if os(iOS) || os(tvOS)
+@available(iOSApplicationExtension, unavailable)
 struct ToastViewIsPresentedModifier<QTContent>: ViewModifier where QTContent: View {
   @Binding var isPresented: Bool
   let dismissAfter: Double?

--- a/Sources/ToastUI/ToastViewModifier.swift
+++ b/Sources/ToastUI/ToastViewModifier.swift
@@ -112,6 +112,7 @@ struct ToastViewIsPresentedModifier<QTContent>: ViewModifier where QTContent: Vi
 #endif
 
 #if os(iOS) || os(tvOS)
+@available(iOSApplicationExtension, unavailable)
 struct ToastViewItemModifier<Item, QTContent>: ViewModifier
 where Item: Identifiable & Equatable, QTContent: View {
   @Binding var item: Item?


### PR DESCRIPTION
#### Fixed

Fix the "'shared' is unavailable in application extensions" error for Xcode 13

#### Checklist

<!--- Put an `x` in all the boxes that apply: -->

* [ ] Screenshots attached (if relevant).
* [ ] Relevant documentation updated.
